### PR TITLE
chore(index.js): removes duplicated compress declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,6 @@ module.exports.compressSync = function compressSync(input) {
   return _compressSync(Buffer.isBuffer(input) ? input : Buffer.from(input))
 }
 
-module.exports.compress = function compress(input) {
-  return _compress(Buffer.isBuffer(input) ? input : Buffer.from(input))
-}
-
 module.exports.uncompress = function uncompress(input, opt = { asBuffer: true }) {
   return _uncompress(input, Boolean(opt.asBuffer))
 }


### PR DESCRIPTION
There is a duplicated `compress` export, this PR removes one!