### PR TITLE
fix: allow access to package.json via export

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       "require": "./index.js",
       "types": "./index.d.ts",
       "browser": "./browser.js"
-    }
+    },
+    "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
**Description:**

This PR fixes the issue where requiring `snappy/package.json` directly fails with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in snappy/package.json
```

**Issue:**

* Node.js blocks access to `package.json` in Snappy 7.3.2+ because the `"exports"` field does not include `./package.json`.
* Projects or scripts that require `snappy/package.json` directly fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

**Fix:**

* Add `./package.json` to the `"exports"` field in `snappy/package.json` to allow direct access while keeping the existing entry points intact.

**References:**

* Node.js package entry points documentation: [https://nodejs.org/api/packages.html#package-entry-points](https://nodejs.org/api/packages.html#package-entry-points)


Closes: https://github.com/Brooooooklyn/snappy/issues/283
