### PR TITLE
fix: restore index.js deleted by napi artifacts during publish

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -426,9 +426,25 @@ jobs:
           path: artifacts
       - name: Move artifacts
         run: yarn artifacts
+      # `napi artifacts` deletes the committed index.js: the wasi loader metadata in
+      # snappy.wasi.cjs lists it as a managed root entry, and since package.json's
+      # main is main.js, artifacts treats index.js as stale. Restore it from git.
+      - name: Restore index.js
+        run: git checkout -- index.js
       - name: List packages
         run: ls -R ./npm
         shell: bash
+      # npm pack silently skips missing entries of the `files` array; fail loudly instead
+      - name: Verify package files exist
+        run: |
+          node -e "
+            const fs = require('fs')
+            const missing = require('./package.json').files.filter((f) => !fs.existsSync(f))
+            if (missing.length) {
+              console.error('Files declared in package.json but missing on disk: ' + missing.join(', '))
+              process.exit(1)
+            }
+          "
       - name: Publish
         run: |
           if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";


### PR DESCRIPTION
## Problem

snappy@7.4.1 on npm is missing `index.js`, so `require('snappy')` → `main.js` → `require('./index.js')` fails with `MODULE_NOT_FOUND`.

## Root cause

The published tarball is packed in the CI publish job *after* `yarn artifacts` runs. `napi artifacts` deletes the committed `index.js` from the workspace:

1. The committed `snappy.wasi.cjs` carries napi-generated metadata: `managedRootEntries: ["browser.js", "index.js", "snappy.wasm", "snappy.debug.wasm"]`.
2. `napi artifacts` considers those files CLI-managed generated files. Since `package.json`'s `main` is the hand-written `main.js`, the artifacts step only re-writes `main.js` (and regenerates `browser.js`), leaving `index.js` without a pending write.
3. `collectStaleManagedDestinations` then classifies `index.js` as stale and deletes it.
4. `npm pack` silently skips `files` entries that don't exist on disk → tarball ships without `index.js` (11 files instead of 12).

Verified by replaying the exact CI publish-job steps in a fresh clone: `napi artifacts` deletes `index.js`, and the resulting tarball misses it. 7.4.0 masked the same deletion because the old `prepublishOnly` esbuild step re-created `index.js` (via the `browser` field remap to `browser-entry.js` — the wrong content reported in #352). Removing the esbuild step in #353 exposed the underlying deletion.

## Fix

- After `yarn artifacts`, restore `index.js` from git. The committed `index.js` is the platform-independent loader generated by `napi build` during `preversion`, so restoring it ships the correct content.
- Add a pre-publish guard that fails the job if any file declared in `package.json`'s `files` is missing on disk, so npm pack can never silently omit files again.

Verified locally: after the restore step, `npm pack` includes `index.js` (12 files total) and `require('snappy')` loads.